### PR TITLE
fix: appVersion handling from Chart.yaml (instatt of values)

### DIFF
--- a/charts/log-generator/templates/deployment.yaml
+++ b/charts/log-generator/templates/deployment.yaml
@@ -27,7 +27,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - /loggen

--- a/charts/log-generator/values.yaml
+++ b/charts/log-generator/values.yaml
@@ -6,7 +6,8 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/kube-logging/log-generator
-  tag: 0.4.0
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/log-socket/values.yaml
+++ b/charts/log-socket/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: ghcr.io/banzaicloud/log-socket
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "latest"
+  tag: ""
 
 imagePullSecrets: []
 nameOverride: ""

--- a/charts/logging-demo/Chart.yaml
+++ b/charts/logging-demo/Chart.yaml
@@ -2,7 +2,6 @@ apiVersion: v2
 type: application
 name: logging-demo
 version: 4.0.0-rc18-1
-appVersion: 4.0.0-rc17
 kubeVersion: ">=1.16.0-0"
 description: Logging operator demo application
 keywords:

--- a/charts/logging-operator-logging/Chart.yaml
+++ b/charts/logging-operator-logging/Chart.yaml
@@ -2,7 +2,6 @@ apiVersion: v2
 type: application
 name: logging-operator-logging
 version: 4.0.0-rc18-1
-appVersion: 4.0.0-rc17
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart to configure logging resource for the Logging operator.
 keywords:

--- a/charts/logging-operator/templates/deployment.yaml
+++ b/charts/logging-operator/templates/deployment.yaml
@@ -33,7 +33,7 @@ spec:
     {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           args:
           {{- range .Values.extraArgs }}
             - {{ . }}

--- a/charts/logging-operator/values.yaml
+++ b/charts/logging-operator/values.yaml
@@ -9,7 +9,7 @@ image:
   repository: ghcr.io/banzaicloud/logging-operator
 
   # -- Image tag override for the default value (chart appVersion).
-  tag: 4.0.0-rc17
+  tag: ""
 
   # -- [Image pull policy](https://kubernetes.io/docs/concepts/containers/images/#updating-images) for updating already existing images on a node.
   pullPolicy: IfNotPresent


### PR DESCRIPTION
1. `appVersion` in `Charts.yaml` should always be the current version (of operator ...)
    - on charts like demo without an appVersion not set   
2. by default the appVersion as tag should be used (instatt of an value in `values.yaml`)
    - keep tag in `values.yaml` so user could overwrite `tags` if an other then appVersion is wanted