### PR TITLE
fix: sync chart from logging-operator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ bin/
 values.local.yaml
 values.test.yaml
 .DS_Store
+.idea

--- a/charts/log-generator/Chart.yaml
+++ b/charts/log-generator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: log-generator
-version: 0.2.1
+version: 0.2.2-dev.1
 appVersion: 0.4.1
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart for Log-generator

--- a/charts/log-generator/README.md
+++ b/charts/log-generator/README.md
@@ -1,6 +1,6 @@
 # log-generator
 
-![version: 0.2.0](https://img.shields.io/badge/version-0.2.0-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 0.4.1](https://img.shields.io/badge/app%20version-0.4.1-informational?style=flat-square) ![kube version: >=1.16.0-0](https://img.shields.io/badge/kube%20version->=1.16.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-log--generator-informational?style=flat-square)](https://artifacthub.io/packages/helm/kube-logging/log-generator)
+![version: 0.2.1](https://img.shields.io/badge/version-0.2.1-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 0.4.1](https://img.shields.io/badge/app%20version-0.4.1-informational?style=flat-square) ![kube version: >=1.16.0-0](https://img.shields.io/badge/kube%20version->=1.16.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-log--generator-informational?style=flat-square)](https://artifacthub.io/packages/helm/kube-logging/log-generator)
 
 A Helm chart for Log-generator
 
@@ -19,7 +19,7 @@ helm install --generate-name --wait kube-logging/log-generator
 |-----|------|---------|-------------|
 | replicaCount | int | `1` |  |
 | image.repository | string | `"ghcr.io/kube-logging/log-generator"` |  |
-| image.tag | string | `"0.4.0"` |  |
+| image.tag | string | `"v0.4.1"` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | imagePullSecrets | list | `[]` |  |
 | nameOverride | string | `""` |  |

--- a/charts/log-generator/README.md
+++ b/charts/log-generator/README.md
@@ -1,6 +1,6 @@
 # log-generator
 
-![version: 0.2.1](https://img.shields.io/badge/version-0.2.1-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 0.4.1](https://img.shields.io/badge/app%20version-0.4.1-informational?style=flat-square) ![kube version: >=1.16.0-0](https://img.shields.io/badge/kube%20version->=1.16.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-log--generator-informational?style=flat-square)](https://artifacthub.io/packages/helm/kube-logging/log-generator)
+![version: 0.2.2-dev.1](https://img.shields.io/badge/version-0.2.2--dev.1-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 0.4.1](https://img.shields.io/badge/app%20version-0.4.1-informational?style=flat-square) ![kube version: >=1.16.0-0](https://img.shields.io/badge/kube%20version->=1.16.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-log--generator-informational?style=flat-square)](https://artifacthub.io/packages/helm/kube-logging/log-generator)
 
 A Helm chart for Log-generator
 

--- a/charts/logging-demo/Chart.yaml
+++ b/charts/logging-demo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: logging-demo
-version: 4.0.0
+version: 4.0.1-dev.1
 appVersion: 4.0.0
 kubeVersion: ">=1.16.0-0"
 description: Logging operator demo application

--- a/charts/logging-demo/README.md
+++ b/charts/logging-demo/README.md
@@ -1,6 +1,6 @@
 # logging-demo
 
-![version: 4.0.0](https://img.shields.io/badge/version-4.0.0-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 4.0.0](https://img.shields.io/badge/app%20version-4.0.0-informational?style=flat-square) ![kube version: >=1.16.0-0](https://img.shields.io/badge/kube%20version->=1.16.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-logging--demo-informational?style=flat-square)](https://artifacthub.io/packages/helm/kube-logging/logging-demo)
+![version: 4.0.1-dev.1](https://img.shields.io/badge/version-4.0.1--dev.1-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 4.0.0](https://img.shields.io/badge/app%20version-4.0.0-informational?style=flat-square) ![kube version: >=1.16.0-0](https://img.shields.io/badge/kube%20version->=1.16.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-logging--demo-informational?style=flat-square)](https://artifacthub.io/packages/helm/kube-logging/logging-demo)
 
 Logging operator demo application
 

--- a/charts/logging-demo/README.md
+++ b/charts/logging-demo/README.md
@@ -1,6 +1,6 @@
 # logging-demo
 
-![version: 4.0.0-rc18-1](https://img.shields.io/badge/version-4.0.0--rc18--1-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 4.0.0-rc17](https://img.shields.io/badge/app%20version-4.0.0--rc17-informational?style=flat-square) ![kube version: >=1.16.0-0](https://img.shields.io/badge/kube%20version->=1.16.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-logging--demo-informational?style=flat-square)](https://artifacthub.io/packages/helm/kube-logging/logging-demo)
+![version: 4.0.0](https://img.shields.io/badge/version-4.0.0-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 4.0.0](https://img.shields.io/badge/app%20version-4.0.0-informational?style=flat-square) ![kube version: >=1.16.0-0](https://img.shields.io/badge/kube%20version->=1.16.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-logging--demo-informational?style=flat-square)](https://artifacthub.io/packages/helm/kube-logging/logging-demo)
 
 Logging operator demo application
 
@@ -16,7 +16,7 @@ helm install --generate-name --wait kube-logging/logging-demo
 ## Introduction
 
 This chart demonstrates the use of the [Logging Operator](https://github.com/kube-logging/helm-charts/tree/main/charts/logging-operator) with a
-[Log-Generator](https://github.com/kube-logging/log-generator) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+[Log-Generator](https://github.com/banzaicloud/log-generator) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 ## Prerequisites
 

--- a/charts/logging-operator-logging/Chart.yaml
+++ b/charts/logging-operator-logging/Chart.yaml
@@ -2,7 +2,6 @@ apiVersion: v2
 type: application
 name: logging-operator-logging
 version: 4.1.0-dev.1
-appVersion: 4.0.0
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart to configure logging resource for the Logging operator.
 keywords:

--- a/charts/logging-operator-logging/Chart.yaml
+++ b/charts/logging-operator-logging/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: logging-operator-logging
-version: 4.0.0
+version: 4.1.0-dev.1
 appVersion: 4.0.0
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart to configure logging resource for the Logging operator.

--- a/charts/logging-operator-logging/README.md
+++ b/charts/logging-operator-logging/README.md
@@ -1,6 +1,6 @@
 # logging-operator-logging
 
-![version: 4.0.0-rc18-1](https://img.shields.io/badge/version-4.0.0--rc18--1-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 4.0.0-rc17](https://img.shields.io/badge/app%20version-4.0.0--rc17-informational?style=flat-square) ![kube version: >=1.16.0-0](https://img.shields.io/badge/kube%20version->=1.16.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-logging--operator--logging-informational?style=flat-square)](https://artifacthub.io/packages/helm/kube-logging/logging-operator-logging)
+![version: 4.1.0-dev.1](https://img.shields.io/badge/version-4.1.0--dev.1-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square)  ![kube version: >=1.16.0-0](https://img.shields.io/badge/kube%20version->=1.16.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-logging--operator--logging-informational?style=flat-square)](https://artifacthub.io/packages/helm/kube-logging/logging-operator-logging)
 
 A Helm chart to configure logging resource for the Logging operator.
 

--- a/charts/logging-operator/Chart.yaml
+++ b/charts/logging-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: logging-operator
-version: 4.0.0
+version: 4.1.0-dev.1
 appVersion: 4.0.0
 kubeVersion: ">=1.16.0-0"
 description: Logging operator for Kubernetes based on Fluentd and Fluentbit.

--- a/charts/logging-operator/README.md
+++ b/charts/logging-operator/README.md
@@ -1,6 +1,6 @@
 # logging-operator
 
-![version: 4.0.0-rc19-3](https://img.shields.io/badge/version-4.0.0--rc19--3-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 4.0.0-rc19](https://img.shields.io/badge/app%20version-4.0.0--rc19-informational?style=flat-square) ![kube version: >=1.16.0-0](https://img.shields.io/badge/kube%20version->=1.16.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-logging--operator-informational?style=flat-square)](https://artifacthub.io/packages/helm/kube-logging/logging-operator)
+![version: 4.1.0-dev.1](https://img.shields.io/badge/version-4.1.0--dev.1-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 4.0.0](https://img.shields.io/badge/app%20version-4.0.0-informational?style=flat-square) ![kube version: >=1.16.0-0](https://img.shields.io/badge/kube%20version->=1.16.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-logging--operator-informational?style=flat-square)](https://artifacthub.io/packages/helm/kube-logging/logging-operator)
 
 Logging operator for Kubernetes based on Fluentd and Fluentbit.
 
@@ -31,7 +31,7 @@ Use `createCustomResource=false` with Helm v3 to avoid trying to create CRDs fro
 |-----|------|---------|-------------|
 | replicaCount | int | `1` |  |
 | image.repository | string | `"ghcr.io/kube-logging/logging-operator"` | Name of the image repository to pull the container image from. |
-| image.tag | string | `"4.0.0"` | Image tag override for the default value (chart appVersion). |
+| image.tag | string | `""` | Image tag override for the default value (chart appVersion). |
 | image.pullPolicy | string | `"IfNotPresent"` | [Image pull policy](https://kubernetes.io/docs/concepts/containers/images/#updating-images) for updating already existing images on a node. |
 | env | list | `[]` |  |
 | volumes | list | `[]` |  |

--- a/charts/logging-operator/crds/logging-extensions.banzaicloud.io_eventtailers.yaml
+++ b/charts/logging-operator/crds/logging-extensions.banzaicloud.io_eventtailers.yaml
@@ -198,6 +198,18 @@ spec:
                     type: object
                   resources:
                     properties:
+                      claims:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
                       limits:
                         additionalProperties:
                           anyOf:
@@ -367,12 +379,26 @@ spec:
                                 type: string
                               name:
                                 type: string
+                              namespace:
+                                type: string
                             required:
                             - kind
                             - name
                             type: object
                           resources:
                             properties:
+                              claims:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
                               limits:
                                 additionalProperties:
                                   anyOf:
@@ -960,6 +986,18 @@ spec:
                           type: object
                         resources:
                           properties:
+                            claims:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
                             limits:
                               additionalProperties:
                                 anyOf:
@@ -1238,6 +1276,18 @@ spec:
                           type: object
                         resources:
                           properties:
+                            claims:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
                             limits:
                               additionalProperties:
                                 anyOf:
@@ -1641,12 +1691,26 @@ spec:
                                           type: string
                                         name:
                                           type: string
+                                        namespace:
+                                          type: string
                                       required:
                                       - kind
                                       - name
                                       type: object
                                     resources:
                                       properties:
+                                        claims:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
                                         limits:
                                           additionalProperties:
                                             anyOf:

--- a/charts/logging-operator/crds/logging-extensions.banzaicloud.io_hosttailers.yaml
+++ b/charts/logging-operator/crds/logging-extensions.banzaicloud.io_hosttailers.yaml
@@ -207,6 +207,18 @@ spec:
                           type: object
                         resources:
                           properties:
+                            claims:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
                             limits:
                               additionalProperties:
                                 anyOf:
@@ -493,6 +505,18 @@ spec:
                           type: object
                         resources:
                           properties:
+                            claims:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
                             limits:
                               additionalProperties:
                                 anyOf:
@@ -1144,6 +1168,18 @@ spec:
                           type: object
                         resources:
                           properties:
+                            claims:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
                             limits:
                               additionalProperties:
                                 anyOf:
@@ -1422,6 +1458,18 @@ spec:
                           type: object
                         resources:
                           properties:
+                            claims:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
                             limits:
                               additionalProperties:
                                 anyOf:
@@ -1825,12 +1873,26 @@ spec:
                                           type: string
                                         name:
                                           type: string
+                                        namespace:
+                                          type: string
                                       required:
                                       - kind
                                       - name
                                       type: object
                                     resources:
                                       properties:
+                                        claims:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
                                         limits:
                                           additionalProperties:
                                             anyOf:

--- a/charts/logging-operator/crds/logging.banzaicloud.io_loggings.yaml
+++ b/charts/logging-operator/crds/logging.banzaicloud.io_loggings.yaml
@@ -1443,12 +1443,26 @@ spec:
                                     type: string
                                   name:
                                     type: string
+                                  namespace:
+                                    type: string
                                 required:
                                 - kind
                                 - name
                                 type: object
                               resources:
                                 properties:
+                                  claims:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - name
+                                    x-kubernetes-list-type: map
                                   limits:
                                     additionalProperties:
                                       anyOf:
@@ -2515,12 +2529,26 @@ spec:
                                     type: string
                                   name:
                                     type: string
+                                  namespace:
+                                    type: string
                                 required:
                                 - kind
                                 - name
                                 type: object
                               resources:
                                 properties:
+                                  claims:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - name
+                                    x-kubernetes-list-type: map
                                   limits:
                                     additionalProperties:
                                       anyOf:
@@ -2638,12 +2666,26 @@ spec:
                                     type: string
                                   name:
                                     type: string
+                                  namespace:
+                                    type: string
                                 required:
                                 - kind
                                 - name
                                 type: object
                               resources:
                                 properties:
+                                  claims:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - name
+                                    x-kubernetes-list-type: map
                                   limits:
                                     additionalProperties:
                                       anyOf:
@@ -2773,6 +2815,18 @@ spec:
                     type: object
                   resources:
                     properties:
+                      claims:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
                       limits:
                         additionalProperties:
                           anyOf:
@@ -3452,12 +3506,26 @@ spec:
                                     type: string
                                   name:
                                     type: string
+                                  namespace:
+                                    type: string
                                 required:
                                 - kind
                                 - name
                                 type: object
                               resources:
                                 properties:
+                                  claims:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - name
+                                    x-kubernetes-list-type: map
                                   limits:
                                     additionalProperties:
                                       anyOf:
@@ -3724,6 +3792,18 @@ spec:
                     type: object
                   configCheckResources:
                     properties:
+                      claims:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
                       limits:
                         additionalProperties:
                           anyOf:
@@ -3759,6 +3839,18 @@ spec:
                     type: object
                   configReloaderResources:
                     properties:
+                      claims:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
                       limits:
                         additionalProperties:
                           anyOf:
@@ -3941,12 +4033,26 @@ spec:
                                           type: string
                                         name:
                                           type: string
+                                        namespace:
+                                          type: string
                                       required:
                                       - kind
                                       - name
                                       type: object
                                     resources:
                                       properties:
+                                        claims:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
                                         limits:
                                           additionalProperties:
                                             anyOf:
@@ -4083,12 +4189,26 @@ spec:
                                     type: string
                                   name:
                                     type: string
+                                  namespace:
+                                    type: string
                                 required:
                                 - kind
                                 - name
                                 type: object
                               resources:
                                 properties:
+                                  claims:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - name
+                                    x-kubernetes-list-type: map
                                   limits:
                                     additionalProperties:
                                       anyOf:
@@ -4620,6 +4740,18 @@ spec:
                     type: object
                   resources:
                     properties:
+                      claims:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
                       limits:
                         additionalProperties:
                           anyOf:
@@ -5996,12 +6128,26 @@ spec:
                                           type: string
                                         name:
                                           type: string
+                                        namespace:
+                                          type: string
                                       required:
                                       - kind
                                       - name
                                       type: object
                                     resources:
                                       properties:
+                                        claims:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
                                         limits:
                                           additionalProperties:
                                             anyOf:
@@ -6859,6 +7005,18 @@ spec:
                                                 type: object
                                               resources:
                                                 properties:
+                                                  claims:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-map-keys:
+                                                    - name
+                                                    x-kubernetes-list-type: map
                                                   limits:
                                                     additionalProperties:
                                                       anyOf:
@@ -7470,6 +7628,18 @@ spec:
                                                 type: object
                                               resources:
                                                 properties:
+                                                  claims:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-map-keys:
+                                                    - name
+                                                    x-kubernetes-list-type: map
                                                   limits:
                                                     additionalProperties:
                                                       anyOf:
@@ -8085,6 +8255,18 @@ spec:
                                                 type: object
                                               resources:
                                                 properties:
+                                                  claims:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-map-keys:
+                                                    - name
+                                                    x-kubernetes-list-type: map
                                                   limits:
                                                     additionalProperties:
                                                       anyOf:
@@ -8686,12 +8868,26 @@ spec:
                                                                 type: string
                                                               name:
                                                                 type: string
+                                                              namespace:
+                                                                type: string
                                                             required:
                                                             - kind
                                                             - name
                                                             type: object
                                                           resources:
                                                             properties:
+                                                              claims:
+                                                                items:
+                                                                  properties:
+                                                                    name:
+                                                                      type: string
+                                                                  required:
+                                                                  - name
+                                                                  type: object
+                                                                type: array
+                                                                x-kubernetes-list-map-keys:
+                                                                - name
+                                                                x-kubernetes-list-type: map
                                                               limits:
                                                                 additionalProperties:
                                                                   anyOf:
@@ -9753,12 +9949,26 @@ spec:
                                           type: string
                                         name:
                                           type: string
+                                        namespace:
+                                          type: string
                                       required:
                                       - kind
                                       - name
                                       type: object
                                     resources:
                                       properties:
+                                        claims:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
                                         limits:
                                           additionalProperties:
                                             anyOf:
@@ -11049,6 +11259,18 @@ spec:
                               type: object
                             resources:
                               properties:
+                                claims:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - name
+                                  x-kubernetes-list-type: map
                                 limits:
                                   additionalProperties:
                                     anyOf:
@@ -11660,6 +11882,18 @@ spec:
                               type: object
                             resources:
                               properties:
+                                claims:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - name
+                                  x-kubernetes-list-type: map
                                 limits:
                                   additionalProperties:
                                     anyOf:
@@ -12275,6 +12509,18 @@ spec:
                               type: object
                             resources:
                               properties:
+                                claims:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - name
+                                  x-kubernetes-list-type: map
                                 limits:
                                   additionalProperties:
                                     anyOf:
@@ -12876,12 +13122,26 @@ spec:
                                               type: string
                                             name:
                                               type: string
+                                            namespace:
+                                              type: string
                                           required:
                                           - kind
                                           - name
                                           type: object
                                         resources:
                                           properties:
+                                            claims:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                required:
+                                                - name
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-map-keys:
+                                              - name
+                                              x-kubernetes-list-type: map
                                             limits:
                                               additionalProperties:
                                                 anyOf:
@@ -14629,6 +14889,18 @@ spec:
                                           type: object
                                         resources:
                                           properties:
+                                            claims:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                required:
+                                                - name
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-map-keys:
+                                              - name
+                                              x-kubernetes-list-type: map
                                             limits:
                                               additionalProperties:
                                                 anyOf:
@@ -15240,6 +15512,18 @@ spec:
                                           type: object
                                         resources:
                                           properties:
+                                            claims:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                required:
+                                                - name
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-map-keys:
+                                              - name
+                                              x-kubernetes-list-type: map
                                             limits:
                                               additionalProperties:
                                                 anyOf:
@@ -15855,6 +16139,18 @@ spec:
                                           type: object
                                         resources:
                                           properties:
+                                            claims:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                required:
+                                                - name
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-map-keys:
+                                              - name
+                                              x-kubernetes-list-type: map
                                             limits:
                                               additionalProperties:
                                                 anyOf:
@@ -16456,12 +16752,26 @@ spec:
                                                           type: string
                                                         name:
                                                           type: string
+                                                        namespace:
+                                                          type: string
                                                       required:
                                                       - kind
                                                       - name
                                                       type: object
                                                     resources:
                                                       properties:
+                                                        claims:
+                                                          items:
+                                                            properties:
+                                                              name:
+                                                                type: string
+                                                            required:
+                                                            - name
+                                                            type: object
+                                                          type: array
+                                                          x-kubernetes-list-map-keys:
+                                                          - name
+                                                          x-kubernetes-list-type: map
                                                         limits:
                                                           additionalProperties:
                                                             anyOf:
@@ -16981,12 +17291,26 @@ spec:
                                           type: string
                                         name:
                                           type: string
+                                        namespace:
+                                          type: string
                                       required:
                                       - kind
                                       - name
                                       type: object
                                     resources:
                                       properties:
+                                        claims:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
                                         limits:
                                           additionalProperties:
                                             anyOf:

--- a/charts/logging-operator/crds/logging.banzaicloud.io_nodeagents.yaml
+++ b/charts/logging-operator/crds/logging.banzaicloud.io_nodeagents.yaml
@@ -1,0 +1,4227 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.0
+  creationTimestamp: null
+  name: nodeagents.logging.banzaicloud.io
+spec:
+  group: logging.banzaicloud.io
+  names:
+    categories:
+    - logging-all
+    kind: NodeAgent
+    listKind: NodeAgentList
+    plural: nodeagents
+    singular: nodeagent
+  scope: Cluster
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              loggingRef:
+                type: string
+              metadata:
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                type: object
+              nodeAgentFluentbit:
+                properties:
+                  bufferStorage:
+                    properties:
+                      storage.backlog.mem_limit:
+                        type: string
+                      storage.checksum:
+                        type: string
+                      storage.path:
+                        type: string
+                      storage.sync:
+                        type: string
+                    type: object
+                  bufferStorageVolume:
+                    properties:
+                      emptyDir:
+                        properties:
+                          medium:
+                            type: string
+                          sizeLimit:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      host_path:
+                        properties:
+                          path:
+                            type: string
+                          type:
+                            type: string
+                        required:
+                        - path
+                        type: object
+                      hostPath:
+                        properties:
+                          path:
+                            type: string
+                          type:
+                            type: string
+                        required:
+                        - path
+                        type: object
+                      pvc:
+                        properties:
+                          source:
+                            properties:
+                              claimName:
+                                type: string
+                              readOnly:
+                                type: boolean
+                            required:
+                            - claimName
+                            type: object
+                          spec:
+                            properties:
+                              accessModes:
+                                items:
+                                  type: string
+                                type: array
+                              dataSource:
+                                properties:
+                                  apiGroup:
+                                    type: string
+                                  kind:
+                                    type: string
+                                  name:
+                                    type: string
+                                required:
+                                - kind
+                                - name
+                                type: object
+                              dataSourceRef:
+                                properties:
+                                  apiGroup:
+                                    type: string
+                                  kind:
+                                    type: string
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
+                                required:
+                                - kind
+                                - name
+                                type: object
+                              resources:
+                                properties:
+                                  claims:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - name
+                                    x-kubernetes-list-type: map
+                                  limits:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    type: object
+                                  requests:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    type: object
+                                type: object
+                              selector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                              storageClassName:
+                                type: string
+                              volumeMode:
+                                type: string
+                              volumeName:
+                                type: string
+                            type: object
+                        type: object
+                    type: object
+                  containersPath:
+                    type: string
+                  coroStackSize:
+                    format: int32
+                    type: integer
+                  customConfigSecret:
+                    type: string
+                  daemonSet:
+                    properties:
+                      metadata:
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          labels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        type: object
+                      spec:
+                        properties:
+                          minReadySeconds:
+                            format: int32
+                            type: integer
+                          revisionHistoryLimit:
+                            format: int32
+                            type: integer
+                          selector:
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                          template:
+                            properties:
+                              metadata:
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  labels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                              spec:
+                                properties:
+                                  activeDeadlineSeconds:
+                                    format: int64
+                                    type: integer
+                                  affinity:
+                                    properties:
+                                      nodeAffinity:
+                                        properties:
+                                          preferredDuringSchedulingIgnoredDuringExecution:
+                                            items:
+                                              properties:
+                                                preference:
+                                                  properties:
+                                                    matchExpressions:
+                                                      items:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          operator:
+                                                            type: string
+                                                          values:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchFields:
+                                                      items:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          operator:
+                                                            type: string
+                                                          values:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                  type: object
+                                                weight:
+                                                  format: int32
+                                                  type: integer
+                                              required:
+                                              - preference
+                                              - weight
+                                              type: object
+                                            type: array
+                                          requiredDuringSchedulingIgnoredDuringExecution:
+                                            properties:
+                                              nodeSelectorTerms:
+                                                items:
+                                                  properties:
+                                                    matchExpressions:
+                                                      items:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          operator:
+                                                            type: string
+                                                          values:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchFields:
+                                                      items:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          operator:
+                                                            type: string
+                                                          values:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                  type: object
+                                                type: array
+                                            required:
+                                            - nodeSelectorTerms
+                                            type: object
+                                        type: object
+                                      podAffinity:
+                                        properties:
+                                          preferredDuringSchedulingIgnoredDuringExecution:
+                                            items:
+                                              properties:
+                                                podAffinityTerm:
+                                                  properties:
+                                                    labelSelector:
+                                                      properties:
+                                                        matchExpressions:
+                                                          items:
+                                                            properties:
+                                                              key:
+                                                                type: string
+                                                              operator:
+                                                                type: string
+                                                              values:
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                        matchLabels:
+                                                          additionalProperties:
+                                                            type: string
+                                                          type: object
+                                                      type: object
+                                                    namespaceSelector:
+                                                      properties:
+                                                        matchExpressions:
+                                                          items:
+                                                            properties:
+                                                              key:
+                                                                type: string
+                                                              operator:
+                                                                type: string
+                                                              values:
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                        matchLabels:
+                                                          additionalProperties:
+                                                            type: string
+                                                          type: object
+                                                      type: object
+                                                    namespaces:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                    topologyKey:
+                                                      type: string
+                                                  required:
+                                                  - topologyKey
+                                                  type: object
+                                                weight:
+                                                  format: int32
+                                                  type: integer
+                                              required:
+                                              - podAffinityTerm
+                                              - weight
+                                              type: object
+                                            type: array
+                                          requiredDuringSchedulingIgnoredDuringExecution:
+                                            items:
+                                              properties:
+                                                labelSelector:
+                                                  properties:
+                                                    matchExpressions:
+                                                      items:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          operator:
+                                                            type: string
+                                                          values:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      type: object
+                                                  type: object
+                                                namespaceSelector:
+                                                  properties:
+                                                    matchExpressions:
+                                                      items:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          operator:
+                                                            type: string
+                                                          values:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      type: object
+                                                  type: object
+                                                namespaces:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                topologyKey:
+                                                  type: string
+                                              required:
+                                              - topologyKey
+                                              type: object
+                                            type: array
+                                        type: object
+                                      podAntiAffinity:
+                                        properties:
+                                          preferredDuringSchedulingIgnoredDuringExecution:
+                                            items:
+                                              properties:
+                                                podAffinityTerm:
+                                                  properties:
+                                                    labelSelector:
+                                                      properties:
+                                                        matchExpressions:
+                                                          items:
+                                                            properties:
+                                                              key:
+                                                                type: string
+                                                              operator:
+                                                                type: string
+                                                              values:
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                        matchLabels:
+                                                          additionalProperties:
+                                                            type: string
+                                                          type: object
+                                                      type: object
+                                                    namespaceSelector:
+                                                      properties:
+                                                        matchExpressions:
+                                                          items:
+                                                            properties:
+                                                              key:
+                                                                type: string
+                                                              operator:
+                                                                type: string
+                                                              values:
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                        matchLabels:
+                                                          additionalProperties:
+                                                            type: string
+                                                          type: object
+                                                      type: object
+                                                    namespaces:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                    topologyKey:
+                                                      type: string
+                                                  required:
+                                                  - topologyKey
+                                                  type: object
+                                                weight:
+                                                  format: int32
+                                                  type: integer
+                                              required:
+                                              - podAffinityTerm
+                                              - weight
+                                              type: object
+                                            type: array
+                                          requiredDuringSchedulingIgnoredDuringExecution:
+                                            items:
+                                              properties:
+                                                labelSelector:
+                                                  properties:
+                                                    matchExpressions:
+                                                      items:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          operator:
+                                                            type: string
+                                                          values:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      type: object
+                                                  type: object
+                                                namespaceSelector:
+                                                  properties:
+                                                    matchExpressions:
+                                                      items:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          operator:
+                                                            type: string
+                                                          values:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      type: object
+                                                  type: object
+                                                namespaces:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                topologyKey:
+                                                  type: string
+                                              required:
+                                              - topologyKey
+                                              type: object
+                                            type: array
+                                        type: object
+                                    type: object
+                                  automountServiceAccountToken:
+                                    type: boolean
+                                  containers:
+                                    items:
+                                      properties:
+                                        args:
+                                          items:
+                                            type: string
+                                          type: array
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                        env:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                              valueFrom:
+                                                properties:
+                                                  configMapKeyRef:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      name:
+                                                        type: string
+                                                      optional:
+                                                        type: boolean
+                                                    required:
+                                                    - key
+                                                    type: object
+                                                  fieldRef:
+                                                    properties:
+                                                      apiVersion:
+                                                        type: string
+                                                      fieldPath:
+                                                        type: string
+                                                    required:
+                                                    - fieldPath
+                                                    type: object
+                                                  resourceFieldRef:
+                                                    properties:
+                                                      containerName:
+                                                        type: string
+                                                      divisor:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        x-kubernetes-int-or-string: true
+                                                      resource:
+                                                        type: string
+                                                    required:
+                                                    - resource
+                                                    type: object
+                                                  secretKeyRef:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      name:
+                                                        type: string
+                                                      optional:
+                                                        type: boolean
+                                                    required:
+                                                    - key
+                                                    type: object
+                                                type: object
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                        envFrom:
+                                          items:
+                                            properties:
+                                              configMapRef:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                type: object
+                                              prefix:
+                                                type: string
+                                              secretRef:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                type: object
+                                            type: object
+                                          type: array
+                                        image:
+                                          type: string
+                                        imagePullPolicy:
+                                          type: string
+                                        lifecycle:
+                                          properties:
+                                            postStart:
+                                              properties:
+                                                exec:
+                                                  properties:
+                                                    command:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  type: object
+                                                httpGet:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    httpHeaders:
+                                                      items:
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          value:
+                                                            type: string
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        type: object
+                                                      type: array
+                                                    path:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      x-kubernetes-int-or-string: true
+                                                    scheme:
+                                                      type: string
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                tcpSocket:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      x-kubernetes-int-or-string: true
+                                                  required:
+                                                  - port
+                                                  type: object
+                                              type: object
+                                            preStop:
+                                              properties:
+                                                exec:
+                                                  properties:
+                                                    command:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  type: object
+                                                httpGet:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    httpHeaders:
+                                                      items:
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          value:
+                                                            type: string
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        type: object
+                                                      type: array
+                                                    path:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      x-kubernetes-int-or-string: true
+                                                    scheme:
+                                                      type: string
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                tcpSocket:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      x-kubernetes-int-or-string: true
+                                                  required:
+                                                  - port
+                                                  type: object
+                                              type: object
+                                          type: object
+                                        livenessProbe:
+                                          properties:
+                                            exec:
+                                              properties:
+                                                command:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              type: object
+                                            failureThreshold:
+                                              format: int32
+                                              type: integer
+                                            grpc:
+                                              properties:
+                                                port:
+                                                  format: int32
+                                                  type: integer
+                                                service:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            httpGet:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            initialDelaySeconds:
+                                              format: int32
+                                              type: integer
+                                            periodSeconds:
+                                              format: int32
+                                              type: integer
+                                            successThreshold:
+                                              format: int32
+                                              type: integer
+                                            tcpSocket:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                            terminationGracePeriodSeconds:
+                                              format: int64
+                                              type: integer
+                                            timeoutSeconds:
+                                              format: int32
+                                              type: integer
+                                          type: object
+                                        name:
+                                          type: string
+                                        ports:
+                                          items:
+                                            properties:
+                                              containerPort:
+                                                format: int32
+                                                type: integer
+                                              hostIP:
+                                                type: string
+                                              hostPort:
+                                                format: int32
+                                                type: integer
+                                              name:
+                                                type: string
+                                              protocol:
+                                                default: TCP
+                                                type: string
+                                            required:
+                                            - containerPort
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - containerPort
+                                          - protocol
+                                          x-kubernetes-list-type: map
+                                        readinessProbe:
+                                          properties:
+                                            exec:
+                                              properties:
+                                                command:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              type: object
+                                            failureThreshold:
+                                              format: int32
+                                              type: integer
+                                            grpc:
+                                              properties:
+                                                port:
+                                                  format: int32
+                                                  type: integer
+                                                service:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            httpGet:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            initialDelaySeconds:
+                                              format: int32
+                                              type: integer
+                                            periodSeconds:
+                                              format: int32
+                                              type: integer
+                                            successThreshold:
+                                              format: int32
+                                              type: integer
+                                            tcpSocket:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                            terminationGracePeriodSeconds:
+                                              format: int64
+                                              type: integer
+                                            timeoutSeconds:
+                                              format: int32
+                                              type: integer
+                                          type: object
+                                        resources:
+                                          properties:
+                                            claims:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                required:
+                                                - name
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-map-keys:
+                                              - name
+                                              x-kubernetes-list-type: map
+                                            limits:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                            requests:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                          type: object
+                                        securityContext:
+                                          properties:
+                                            allowPrivilegeEscalation:
+                                              type: boolean
+                                            capabilities:
+                                              properties:
+                                                add:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                drop:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              type: object
+                                            privileged:
+                                              type: boolean
+                                            procMount:
+                                              type: string
+                                            readOnlyRootFilesystem:
+                                              type: boolean
+                                            runAsGroup:
+                                              format: int64
+                                              type: integer
+                                            runAsNonRoot:
+                                              type: boolean
+                                            runAsUser:
+                                              format: int64
+                                              type: integer
+                                            seLinuxOptions:
+                                              properties:
+                                                level:
+                                                  type: string
+                                                role:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                                user:
+                                                  type: string
+                                              type: object
+                                            seccompProfile:
+                                              properties:
+                                                localhostProfile:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                              required:
+                                              - type
+                                              type: object
+                                            windowsOptions:
+                                              properties:
+                                                gmsaCredentialSpec:
+                                                  type: string
+                                                gmsaCredentialSpecName:
+                                                  type: string
+                                                hostProcess:
+                                                  type: boolean
+                                                runAsUserName:
+                                                  type: string
+                                              type: object
+                                          type: object
+                                        startupProbe:
+                                          properties:
+                                            exec:
+                                              properties:
+                                                command:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              type: object
+                                            failureThreshold:
+                                              format: int32
+                                              type: integer
+                                            grpc:
+                                              properties:
+                                                port:
+                                                  format: int32
+                                                  type: integer
+                                                service:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            httpGet:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            initialDelaySeconds:
+                                              format: int32
+                                              type: integer
+                                            periodSeconds:
+                                              format: int32
+                                              type: integer
+                                            successThreshold:
+                                              format: int32
+                                              type: integer
+                                            tcpSocket:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                            terminationGracePeriodSeconds:
+                                              format: int64
+                                              type: integer
+                                            timeoutSeconds:
+                                              format: int32
+                                              type: integer
+                                          type: object
+                                        stdin:
+                                          type: boolean
+                                        stdinOnce:
+                                          type: boolean
+                                        terminationMessagePath:
+                                          type: string
+                                        terminationMessagePolicy:
+                                          type: string
+                                        tty:
+                                          type: boolean
+                                        volumeDevices:
+                                          items:
+                                            properties:
+                                              devicePath:
+                                                type: string
+                                              name:
+                                                type: string
+                                            required:
+                                            - devicePath
+                                            - name
+                                            type: object
+                                          type: array
+                                        volumeMounts:
+                                          items:
+                                            properties:
+                                              mountPath:
+                                                type: string
+                                              mountPropagation:
+                                                type: string
+                                              name:
+                                                type: string
+                                              readOnly:
+                                                type: boolean
+                                              subPath:
+                                                type: string
+                                              subPathExpr:
+                                                type: string
+                                            required:
+                                            - mountPath
+                                            - name
+                                            type: object
+                                          type: array
+                                        workingDir:
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                  dnsConfig:
+                                    properties:
+                                      nameservers:
+                                        items:
+                                          type: string
+                                        type: array
+                                      options:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                          type: object
+                                        type: array
+                                      searches:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  dnsPolicy:
+                                    type: string
+                                  enableServiceLinks:
+                                    type: boolean
+                                  ephemeralContainers:
+                                    items:
+                                      properties:
+                                        args:
+                                          items:
+                                            type: string
+                                          type: array
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                        env:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                              valueFrom:
+                                                properties:
+                                                  configMapKeyRef:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      name:
+                                                        type: string
+                                                      optional:
+                                                        type: boolean
+                                                    required:
+                                                    - key
+                                                    type: object
+                                                  fieldRef:
+                                                    properties:
+                                                      apiVersion:
+                                                        type: string
+                                                      fieldPath:
+                                                        type: string
+                                                    required:
+                                                    - fieldPath
+                                                    type: object
+                                                  resourceFieldRef:
+                                                    properties:
+                                                      containerName:
+                                                        type: string
+                                                      divisor:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        x-kubernetes-int-or-string: true
+                                                      resource:
+                                                        type: string
+                                                    required:
+                                                    - resource
+                                                    type: object
+                                                  secretKeyRef:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      name:
+                                                        type: string
+                                                      optional:
+                                                        type: boolean
+                                                    required:
+                                                    - key
+                                                    type: object
+                                                type: object
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                        envFrom:
+                                          items:
+                                            properties:
+                                              configMapRef:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                type: object
+                                              prefix:
+                                                type: string
+                                              secretRef:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                type: object
+                                            type: object
+                                          type: array
+                                        image:
+                                          type: string
+                                        imagePullPolicy:
+                                          type: string
+                                        lifecycle:
+                                          properties:
+                                            postStart:
+                                              properties:
+                                                exec:
+                                                  properties:
+                                                    command:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  type: object
+                                                httpGet:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    httpHeaders:
+                                                      items:
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          value:
+                                                            type: string
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        type: object
+                                                      type: array
+                                                    path:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      x-kubernetes-int-or-string: true
+                                                    scheme:
+                                                      type: string
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                tcpSocket:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      x-kubernetes-int-or-string: true
+                                                  required:
+                                                  - port
+                                                  type: object
+                                              type: object
+                                            preStop:
+                                              properties:
+                                                exec:
+                                                  properties:
+                                                    command:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  type: object
+                                                httpGet:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    httpHeaders:
+                                                      items:
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          value:
+                                                            type: string
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        type: object
+                                                      type: array
+                                                    path:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      x-kubernetes-int-or-string: true
+                                                    scheme:
+                                                      type: string
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                tcpSocket:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      x-kubernetes-int-or-string: true
+                                                  required:
+                                                  - port
+                                                  type: object
+                                              type: object
+                                          type: object
+                                        livenessProbe:
+                                          properties:
+                                            exec:
+                                              properties:
+                                                command:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              type: object
+                                            failureThreshold:
+                                              format: int32
+                                              type: integer
+                                            grpc:
+                                              properties:
+                                                port:
+                                                  format: int32
+                                                  type: integer
+                                                service:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            httpGet:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            initialDelaySeconds:
+                                              format: int32
+                                              type: integer
+                                            periodSeconds:
+                                              format: int32
+                                              type: integer
+                                            successThreshold:
+                                              format: int32
+                                              type: integer
+                                            tcpSocket:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                            terminationGracePeriodSeconds:
+                                              format: int64
+                                              type: integer
+                                            timeoutSeconds:
+                                              format: int32
+                                              type: integer
+                                          type: object
+                                        name:
+                                          type: string
+                                        ports:
+                                          items:
+                                            properties:
+                                              containerPort:
+                                                format: int32
+                                                type: integer
+                                              hostIP:
+                                                type: string
+                                              hostPort:
+                                                format: int32
+                                                type: integer
+                                              name:
+                                                type: string
+                                              protocol:
+                                                default: TCP
+                                                type: string
+                                            required:
+                                            - containerPort
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - containerPort
+                                          - protocol
+                                          x-kubernetes-list-type: map
+                                        readinessProbe:
+                                          properties:
+                                            exec:
+                                              properties:
+                                                command:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              type: object
+                                            failureThreshold:
+                                              format: int32
+                                              type: integer
+                                            grpc:
+                                              properties:
+                                                port:
+                                                  format: int32
+                                                  type: integer
+                                                service:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            httpGet:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            initialDelaySeconds:
+                                              format: int32
+                                              type: integer
+                                            periodSeconds:
+                                              format: int32
+                                              type: integer
+                                            successThreshold:
+                                              format: int32
+                                              type: integer
+                                            tcpSocket:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                            terminationGracePeriodSeconds:
+                                              format: int64
+                                              type: integer
+                                            timeoutSeconds:
+                                              format: int32
+                                              type: integer
+                                          type: object
+                                        resources:
+                                          properties:
+                                            claims:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                required:
+                                                - name
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-map-keys:
+                                              - name
+                                              x-kubernetes-list-type: map
+                                            limits:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                            requests:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                          type: object
+                                        securityContext:
+                                          properties:
+                                            allowPrivilegeEscalation:
+                                              type: boolean
+                                            capabilities:
+                                              properties:
+                                                add:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                drop:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              type: object
+                                            privileged:
+                                              type: boolean
+                                            procMount:
+                                              type: string
+                                            readOnlyRootFilesystem:
+                                              type: boolean
+                                            runAsGroup:
+                                              format: int64
+                                              type: integer
+                                            runAsNonRoot:
+                                              type: boolean
+                                            runAsUser:
+                                              format: int64
+                                              type: integer
+                                            seLinuxOptions:
+                                              properties:
+                                                level:
+                                                  type: string
+                                                role:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                                user:
+                                                  type: string
+                                              type: object
+                                            seccompProfile:
+                                              properties:
+                                                localhostProfile:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                              required:
+                                              - type
+                                              type: object
+                                            windowsOptions:
+                                              properties:
+                                                gmsaCredentialSpec:
+                                                  type: string
+                                                gmsaCredentialSpecName:
+                                                  type: string
+                                                hostProcess:
+                                                  type: boolean
+                                                runAsUserName:
+                                                  type: string
+                                              type: object
+                                          type: object
+                                        startupProbe:
+                                          properties:
+                                            exec:
+                                              properties:
+                                                command:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              type: object
+                                            failureThreshold:
+                                              format: int32
+                                              type: integer
+                                            grpc:
+                                              properties:
+                                                port:
+                                                  format: int32
+                                                  type: integer
+                                                service:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            httpGet:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            initialDelaySeconds:
+                                              format: int32
+                                              type: integer
+                                            periodSeconds:
+                                              format: int32
+                                              type: integer
+                                            successThreshold:
+                                              format: int32
+                                              type: integer
+                                            tcpSocket:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                            terminationGracePeriodSeconds:
+                                              format: int64
+                                              type: integer
+                                            timeoutSeconds:
+                                              format: int32
+                                              type: integer
+                                          type: object
+                                        stdin:
+                                          type: boolean
+                                        stdinOnce:
+                                          type: boolean
+                                        targetContainerName:
+                                          type: string
+                                        terminationMessagePath:
+                                          type: string
+                                        terminationMessagePolicy:
+                                          type: string
+                                        tty:
+                                          type: boolean
+                                        volumeDevices:
+                                          items:
+                                            properties:
+                                              devicePath:
+                                                type: string
+                                              name:
+                                                type: string
+                                            required:
+                                            - devicePath
+                                            - name
+                                            type: object
+                                          type: array
+                                        volumeMounts:
+                                          items:
+                                            properties:
+                                              mountPath:
+                                                type: string
+                                              mountPropagation:
+                                                type: string
+                                              name:
+                                                type: string
+                                              readOnly:
+                                                type: boolean
+                                              subPath:
+                                                type: string
+                                              subPathExpr:
+                                                type: string
+                                            required:
+                                            - mountPath
+                                            - name
+                                            type: object
+                                          type: array
+                                        workingDir:
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                  hostAliases:
+                                    items:
+                                      properties:
+                                        hostnames:
+                                          items:
+                                            type: string
+                                          type: array
+                                        ip:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  hostIPC:
+                                    type: boolean
+                                  hostNetwork:
+                                    type: boolean
+                                  hostPID:
+                                    type: boolean
+                                  hostname:
+                                    type: string
+                                  imagePullSecrets:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  initContainers:
+                                    items:
+                                      properties:
+                                        args:
+                                          items:
+                                            type: string
+                                          type: array
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                        env:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                              valueFrom:
+                                                properties:
+                                                  configMapKeyRef:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      name:
+                                                        type: string
+                                                      optional:
+                                                        type: boolean
+                                                    required:
+                                                    - key
+                                                    type: object
+                                                  fieldRef:
+                                                    properties:
+                                                      apiVersion:
+                                                        type: string
+                                                      fieldPath:
+                                                        type: string
+                                                    required:
+                                                    - fieldPath
+                                                    type: object
+                                                  resourceFieldRef:
+                                                    properties:
+                                                      containerName:
+                                                        type: string
+                                                      divisor:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        x-kubernetes-int-or-string: true
+                                                      resource:
+                                                        type: string
+                                                    required:
+                                                    - resource
+                                                    type: object
+                                                  secretKeyRef:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      name:
+                                                        type: string
+                                                      optional:
+                                                        type: boolean
+                                                    required:
+                                                    - key
+                                                    type: object
+                                                type: object
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                        envFrom:
+                                          items:
+                                            properties:
+                                              configMapRef:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                type: object
+                                              prefix:
+                                                type: string
+                                              secretRef:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                type: object
+                                            type: object
+                                          type: array
+                                        image:
+                                          type: string
+                                        imagePullPolicy:
+                                          type: string
+                                        lifecycle:
+                                          properties:
+                                            postStart:
+                                              properties:
+                                                exec:
+                                                  properties:
+                                                    command:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  type: object
+                                                httpGet:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    httpHeaders:
+                                                      items:
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          value:
+                                                            type: string
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        type: object
+                                                      type: array
+                                                    path:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      x-kubernetes-int-or-string: true
+                                                    scheme:
+                                                      type: string
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                tcpSocket:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      x-kubernetes-int-or-string: true
+                                                  required:
+                                                  - port
+                                                  type: object
+                                              type: object
+                                            preStop:
+                                              properties:
+                                                exec:
+                                                  properties:
+                                                    command:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  type: object
+                                                httpGet:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    httpHeaders:
+                                                      items:
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          value:
+                                                            type: string
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        type: object
+                                                      type: array
+                                                    path:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      x-kubernetes-int-or-string: true
+                                                    scheme:
+                                                      type: string
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                tcpSocket:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      x-kubernetes-int-or-string: true
+                                                  required:
+                                                  - port
+                                                  type: object
+                                              type: object
+                                          type: object
+                                        livenessProbe:
+                                          properties:
+                                            exec:
+                                              properties:
+                                                command:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              type: object
+                                            failureThreshold:
+                                              format: int32
+                                              type: integer
+                                            grpc:
+                                              properties:
+                                                port:
+                                                  format: int32
+                                                  type: integer
+                                                service:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            httpGet:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            initialDelaySeconds:
+                                              format: int32
+                                              type: integer
+                                            periodSeconds:
+                                              format: int32
+                                              type: integer
+                                            successThreshold:
+                                              format: int32
+                                              type: integer
+                                            tcpSocket:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                            terminationGracePeriodSeconds:
+                                              format: int64
+                                              type: integer
+                                            timeoutSeconds:
+                                              format: int32
+                                              type: integer
+                                          type: object
+                                        name:
+                                          type: string
+                                        ports:
+                                          items:
+                                            properties:
+                                              containerPort:
+                                                format: int32
+                                                type: integer
+                                              hostIP:
+                                                type: string
+                                              hostPort:
+                                                format: int32
+                                                type: integer
+                                              name:
+                                                type: string
+                                              protocol:
+                                                default: TCP
+                                                type: string
+                                            required:
+                                            - containerPort
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - containerPort
+                                          - protocol
+                                          x-kubernetes-list-type: map
+                                        readinessProbe:
+                                          properties:
+                                            exec:
+                                              properties:
+                                                command:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              type: object
+                                            failureThreshold:
+                                              format: int32
+                                              type: integer
+                                            grpc:
+                                              properties:
+                                                port:
+                                                  format: int32
+                                                  type: integer
+                                                service:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            httpGet:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            initialDelaySeconds:
+                                              format: int32
+                                              type: integer
+                                            periodSeconds:
+                                              format: int32
+                                              type: integer
+                                            successThreshold:
+                                              format: int32
+                                              type: integer
+                                            tcpSocket:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                            terminationGracePeriodSeconds:
+                                              format: int64
+                                              type: integer
+                                            timeoutSeconds:
+                                              format: int32
+                                              type: integer
+                                          type: object
+                                        resources:
+                                          properties:
+                                            claims:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                required:
+                                                - name
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-map-keys:
+                                              - name
+                                              x-kubernetes-list-type: map
+                                            limits:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                            requests:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                          type: object
+                                        securityContext:
+                                          properties:
+                                            allowPrivilegeEscalation:
+                                              type: boolean
+                                            capabilities:
+                                              properties:
+                                                add:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                drop:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              type: object
+                                            privileged:
+                                              type: boolean
+                                            procMount:
+                                              type: string
+                                            readOnlyRootFilesystem:
+                                              type: boolean
+                                            runAsGroup:
+                                              format: int64
+                                              type: integer
+                                            runAsNonRoot:
+                                              type: boolean
+                                            runAsUser:
+                                              format: int64
+                                              type: integer
+                                            seLinuxOptions:
+                                              properties:
+                                                level:
+                                                  type: string
+                                                role:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                                user:
+                                                  type: string
+                                              type: object
+                                            seccompProfile:
+                                              properties:
+                                                localhostProfile:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                              required:
+                                              - type
+                                              type: object
+                                            windowsOptions:
+                                              properties:
+                                                gmsaCredentialSpec:
+                                                  type: string
+                                                gmsaCredentialSpecName:
+                                                  type: string
+                                                hostProcess:
+                                                  type: boolean
+                                                runAsUserName:
+                                                  type: string
+                                              type: object
+                                          type: object
+                                        startupProbe:
+                                          properties:
+                                            exec:
+                                              properties:
+                                                command:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              type: object
+                                            failureThreshold:
+                                              format: int32
+                                              type: integer
+                                            grpc:
+                                              properties:
+                                                port:
+                                                  format: int32
+                                                  type: integer
+                                                service:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            httpGet:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            initialDelaySeconds:
+                                              format: int32
+                                              type: integer
+                                            periodSeconds:
+                                              format: int32
+                                              type: integer
+                                            successThreshold:
+                                              format: int32
+                                              type: integer
+                                            tcpSocket:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                            terminationGracePeriodSeconds:
+                                              format: int64
+                                              type: integer
+                                            timeoutSeconds:
+                                              format: int32
+                                              type: integer
+                                          type: object
+                                        stdin:
+                                          type: boolean
+                                        stdinOnce:
+                                          type: boolean
+                                        terminationMessagePath:
+                                          type: string
+                                        terminationMessagePolicy:
+                                          type: string
+                                        tty:
+                                          type: boolean
+                                        volumeDevices:
+                                          items:
+                                            properties:
+                                              devicePath:
+                                                type: string
+                                              name:
+                                                type: string
+                                            required:
+                                            - devicePath
+                                            - name
+                                            type: object
+                                          type: array
+                                        volumeMounts:
+                                          items:
+                                            properties:
+                                              mountPath:
+                                                type: string
+                                              mountPropagation:
+                                                type: string
+                                              name:
+                                                type: string
+                                              readOnly:
+                                                type: boolean
+                                              subPath:
+                                                type: string
+                                              subPathExpr:
+                                                type: string
+                                            required:
+                                            - mountPath
+                                            - name
+                                            type: object
+                                          type: array
+                                        workingDir:
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                  nodeName:
+                                    type: string
+                                  nodeSelector:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  overhead:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    type: object
+                                  preemptionPolicy:
+                                    type: string
+                                  priority:
+                                    format: int32
+                                    type: integer
+                                  priorityClassName:
+                                    type: string
+                                  readinessGates:
+                                    items:
+                                      properties:
+                                        conditionType:
+                                          type: string
+                                      required:
+                                      - conditionType
+                                      type: object
+                                    type: array
+                                  restartPolicy:
+                                    type: string
+                                  runtimeClassName:
+                                    type: string
+                                  schedulerName:
+                                    type: string
+                                  securityContext:
+                                    properties:
+                                      fsGroup:
+                                        format: int64
+                                        type: integer
+                                      fsGroupChangePolicy:
+                                        type: string
+                                      runAsGroup:
+                                        format: int64
+                                        type: integer
+                                      runAsNonRoot:
+                                        type: boolean
+                                      runAsUser:
+                                        format: int64
+                                        type: integer
+                                      seLinuxOptions:
+                                        properties:
+                                          level:
+                                            type: string
+                                          role:
+                                            type: string
+                                          type:
+                                            type: string
+                                          user:
+                                            type: string
+                                        type: object
+                                      seccompProfile:
+                                        properties:
+                                          localhostProfile:
+                                            type: string
+                                          type:
+                                            type: string
+                                        required:
+                                        - type
+                                        type: object
+                                      supplementalGroups:
+                                        items:
+                                          format: int64
+                                          type: integer
+                                        type: array
+                                      sysctls:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      windowsOptions:
+                                        properties:
+                                          gmsaCredentialSpec:
+                                            type: string
+                                          gmsaCredentialSpecName:
+                                            type: string
+                                          hostProcess:
+                                            type: boolean
+                                          runAsUserName:
+                                            type: string
+                                        type: object
+                                    type: object
+                                  serviceAccountName:
+                                    type: string
+                                  setHostnameAsFQDN:
+                                    type: boolean
+                                  shareProcessNamespace:
+                                    type: boolean
+                                  subdomain:
+                                    type: string
+                                  terminationGracePeriodSeconds:
+                                    format: int64
+                                    type: integer
+                                  tolerations:
+                                    items:
+                                      properties:
+                                        effect:
+                                          type: string
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        tolerationSeconds:
+                                          format: int64
+                                          type: integer
+                                        value:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  topologySpreadConstraints:
+                                    items:
+                                      properties:
+                                        labelSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                        matchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        maxSkew:
+                                          format: int32
+                                          type: integer
+                                        minDomains:
+                                          format: int32
+                                          type: integer
+                                        nodeAffinityPolicy:
+                                          type: string
+                                        nodeTaintsPolicy:
+                                          type: string
+                                        topologyKey:
+                                          type: string
+                                        whenUnsatisfiable:
+                                          type: string
+                                      required:
+                                      - maxSkew
+                                      - topologyKey
+                                      - whenUnsatisfiable
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - topologyKey
+                                    - whenUnsatisfiable
+                                    x-kubernetes-list-type: map
+                                  volumes:
+                                    items:
+                                      properties:
+                                        awsElasticBlockStore:
+                                          properties:
+                                            fsType:
+                                              type: string
+                                            partition:
+                                              format: int32
+                                              type: integer
+                                            readOnly:
+                                              type: boolean
+                                            volumeID:
+                                              type: string
+                                          required:
+                                          - volumeID
+                                          type: object
+                                        azureDisk:
+                                          properties:
+                                            cachingMode:
+                                              type: string
+                                            diskName:
+                                              type: string
+                                            diskURI:
+                                              type: string
+                                            fsType:
+                                              type: string
+                                            kind:
+                                              type: string
+                                            readOnly:
+                                              type: boolean
+                                          required:
+                                          - diskName
+                                          - diskURI
+                                          type: object
+                                        azureFile:
+                                          properties:
+                                            readOnly:
+                                              type: boolean
+                                            secretName:
+                                              type: string
+                                            shareName:
+                                              type: string
+                                          required:
+                                          - secretName
+                                          - shareName
+                                          type: object
+                                        cephfs:
+                                          properties:
+                                            monitors:
+                                              items:
+                                                type: string
+                                              type: array
+                                            path:
+                                              type: string
+                                            readOnly:
+                                              type: boolean
+                                            secretFile:
+                                              type: string
+                                            secretRef:
+                                              properties:
+                                                name:
+                                                  type: string
+                                              type: object
+                                            user:
+                                              type: string
+                                          required:
+                                          - monitors
+                                          type: object
+                                        cinder:
+                                          properties:
+                                            fsType:
+                                              type: string
+                                            readOnly:
+                                              type: boolean
+                                            secretRef:
+                                              properties:
+                                                name:
+                                                  type: string
+                                              type: object
+                                            volumeID:
+                                              type: string
+                                          required:
+                                          - volumeID
+                                          type: object
+                                        configMap:
+                                          properties:
+                                            defaultMode:
+                                              format: int32
+                                              type: integer
+                                            items:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  mode:
+                                                    format: int32
+                                                    type: integer
+                                                  path:
+                                                    type: string
+                                                required:
+                                                - key
+                                                - path
+                                                type: object
+                                              type: array
+                                            name:
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          type: object
+                                        csi:
+                                          properties:
+                                            driver:
+                                              type: string
+                                            fsType:
+                                              type: string
+                                            nodePublishSecretRef:
+                                              properties:
+                                                name:
+                                                  type: string
+                                              type: object
+                                            readOnly:
+                                              type: boolean
+                                            volumeAttributes:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          required:
+                                          - driver
+                                          type: object
+                                        downwardAPI:
+                                          properties:
+                                            defaultMode:
+                                              format: int32
+                                              type: integer
+                                            items:
+                                              items:
+                                                properties:
+                                                  fieldRef:
+                                                    properties:
+                                                      apiVersion:
+                                                        type: string
+                                                      fieldPath:
+                                                        type: string
+                                                    required:
+                                                    - fieldPath
+                                                    type: object
+                                                  mode:
+                                                    format: int32
+                                                    type: integer
+                                                  path:
+                                                    type: string
+                                                  resourceFieldRef:
+                                                    properties:
+                                                      containerName:
+                                                        type: string
+                                                      divisor:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        x-kubernetes-int-or-string: true
+                                                      resource:
+                                                        type: string
+                                                    required:
+                                                    - resource
+                                                    type: object
+                                                required:
+                                                - path
+                                                type: object
+                                              type: array
+                                          type: object
+                                        emptyDir:
+                                          properties:
+                                            medium:
+                                              type: string
+                                            sizeLimit:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                          type: object
+                                        ephemeral:
+                                          properties:
+                                            volumeClaimTemplate:
+                                              properties:
+                                                metadata:
+                                                  type: object
+                                                spec:
+                                                  properties:
+                                                    accessModes:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                    dataSource:
+                                                      properties:
+                                                        apiGroup:
+                                                          type: string
+                                                        kind:
+                                                          type: string
+                                                        name:
+                                                          type: string
+                                                      required:
+                                                      - kind
+                                                      - name
+                                                      type: object
+                                                    dataSourceRef:
+                                                      properties:
+                                                        apiGroup:
+                                                          type: string
+                                                        kind:
+                                                          type: string
+                                                        name:
+                                                          type: string
+                                                        namespace:
+                                                          type: string
+                                                      required:
+                                                      - kind
+                                                      - name
+                                                      type: object
+                                                    resources:
+                                                      properties:
+                                                        claims:
+                                                          items:
+                                                            properties:
+                                                              name:
+                                                                type: string
+                                                            required:
+                                                            - name
+                                                            type: object
+                                                          type: array
+                                                          x-kubernetes-list-map-keys:
+                                                          - name
+                                                          x-kubernetes-list-type: map
+                                                        limits:
+                                                          additionalProperties:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                            x-kubernetes-int-or-string: true
+                                                          type: object
+                                                        requests:
+                                                          additionalProperties:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                            x-kubernetes-int-or-string: true
+                                                          type: object
+                                                      type: object
+                                                    selector:
+                                                      properties:
+                                                        matchExpressions:
+                                                          items:
+                                                            properties:
+                                                              key:
+                                                                type: string
+                                                              operator:
+                                                                type: string
+                                                              values:
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                        matchLabels:
+                                                          additionalProperties:
+                                                            type: string
+                                                          type: object
+                                                      type: object
+                                                    storageClassName:
+                                                      type: string
+                                                    volumeMode:
+                                                      type: string
+                                                    volumeName:
+                                                      type: string
+                                                  type: object
+                                              required:
+                                              - spec
+                                              type: object
+                                          type: object
+                                        fc:
+                                          properties:
+                                            fsType:
+                                              type: string
+                                            lun:
+                                              format: int32
+                                              type: integer
+                                            readOnly:
+                                              type: boolean
+                                            targetWWNs:
+                                              items:
+                                                type: string
+                                              type: array
+                                            wwids:
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        flexVolume:
+                                          properties:
+                                            driver:
+                                              type: string
+                                            fsType:
+                                              type: string
+                                            options:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            readOnly:
+                                              type: boolean
+                                            secretRef:
+                                              properties:
+                                                name:
+                                                  type: string
+                                              type: object
+                                          required:
+                                          - driver
+                                          type: object
+                                        flocker:
+                                          properties:
+                                            datasetName:
+                                              type: string
+                                            datasetUUID:
+                                              type: string
+                                          type: object
+                                        gcePersistentDisk:
+                                          properties:
+                                            fsType:
+                                              type: string
+                                            partition:
+                                              format: int32
+                                              type: integer
+                                            pdName:
+                                              type: string
+                                            readOnly:
+                                              type: boolean
+                                          required:
+                                          - pdName
+                                          type: object
+                                        gitRepo:
+                                          properties:
+                                            directory:
+                                              type: string
+                                            repository:
+                                              type: string
+                                            revision:
+                                              type: string
+                                          required:
+                                          - repository
+                                          type: object
+                                        glusterfs:
+                                          properties:
+                                            endpoints:
+                                              type: string
+                                            path:
+                                              type: string
+                                            readOnly:
+                                              type: boolean
+                                          required:
+                                          - endpoints
+                                          - path
+                                          type: object
+                                        hostPath:
+                                          properties:
+                                            path:
+                                              type: string
+                                            type:
+                                              type: string
+                                          required:
+                                          - path
+                                          type: object
+                                        iscsi:
+                                          properties:
+                                            chapAuthDiscovery:
+                                              type: boolean
+                                            chapAuthSession:
+                                              type: boolean
+                                            fsType:
+                                              type: string
+                                            initiatorName:
+                                              type: string
+                                            iqn:
+                                              type: string
+                                            iscsiInterface:
+                                              type: string
+                                            lun:
+                                              format: int32
+                                              type: integer
+                                            portals:
+                                              items:
+                                                type: string
+                                              type: array
+                                            readOnly:
+                                              type: boolean
+                                            secretRef:
+                                              properties:
+                                                name:
+                                                  type: string
+                                              type: object
+                                            targetPortal:
+                                              type: string
+                                          required:
+                                          - iqn
+                                          - lun
+                                          - targetPortal
+                                          type: object
+                                        name:
+                                          type: string
+                                        nfs:
+                                          properties:
+                                            path:
+                                              type: string
+                                            readOnly:
+                                              type: boolean
+                                            server:
+                                              type: string
+                                          required:
+                                          - path
+                                          - server
+                                          type: object
+                                        persistentVolumeClaim:
+                                          properties:
+                                            claimName:
+                                              type: string
+                                            readOnly:
+                                              type: boolean
+                                          required:
+                                          - claimName
+                                          type: object
+                                        photonPersistentDisk:
+                                          properties:
+                                            fsType:
+                                              type: string
+                                            pdID:
+                                              type: string
+                                          required:
+                                          - pdID
+                                          type: object
+                                        portworxVolume:
+                                          properties:
+                                            fsType:
+                                              type: string
+                                            readOnly:
+                                              type: boolean
+                                            volumeID:
+                                              type: string
+                                          required:
+                                          - volumeID
+                                          type: object
+                                        projected:
+                                          properties:
+                                            defaultMode:
+                                              format: int32
+                                              type: integer
+                                            sources:
+                                              items:
+                                                properties:
+                                                  configMap:
+                                                    properties:
+                                                      items:
+                                                        items:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            mode:
+                                                              format: int32
+                                                              type: integer
+                                                            path:
+                                                              type: string
+                                                          required:
+                                                          - key
+                                                          - path
+                                                          type: object
+                                                        type: array
+                                                      name:
+                                                        type: string
+                                                      optional:
+                                                        type: boolean
+                                                    type: object
+                                                  downwardAPI:
+                                                    properties:
+                                                      items:
+                                                        items:
+                                                          properties:
+                                                            fieldRef:
+                                                              properties:
+                                                                apiVersion:
+                                                                  type: string
+                                                                fieldPath:
+                                                                  type: string
+                                                              required:
+                                                              - fieldPath
+                                                              type: object
+                                                            mode:
+                                                              format: int32
+                                                              type: integer
+                                                            path:
+                                                              type: string
+                                                            resourceFieldRef:
+                                                              properties:
+                                                                containerName:
+                                                                  type: string
+                                                                divisor:
+                                                                  anyOf:
+                                                                  - type: integer
+                                                                  - type: string
+                                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                                  x-kubernetes-int-or-string: true
+                                                                resource:
+                                                                  type: string
+                                                              required:
+                                                              - resource
+                                                              type: object
+                                                          required:
+                                                          - path
+                                                          type: object
+                                                        type: array
+                                                    type: object
+                                                  secret:
+                                                    properties:
+                                                      items:
+                                                        items:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            mode:
+                                                              format: int32
+                                                              type: integer
+                                                            path:
+                                                              type: string
+                                                          required:
+                                                          - key
+                                                          - path
+                                                          type: object
+                                                        type: array
+                                                      name:
+                                                        type: string
+                                                      optional:
+                                                        type: boolean
+                                                    type: object
+                                                  serviceAccountToken:
+                                                    properties:
+                                                      audience:
+                                                        type: string
+                                                      expirationSeconds:
+                                                        format: int64
+                                                        type: integer
+                                                      path:
+                                                        type: string
+                                                    required:
+                                                    - path
+                                                    type: object
+                                                type: object
+                                              type: array
+                                          type: object
+                                        quobyte:
+                                          properties:
+                                            group:
+                                              type: string
+                                            readOnly:
+                                              type: boolean
+                                            registry:
+                                              type: string
+                                            tenant:
+                                              type: string
+                                            user:
+                                              type: string
+                                            volume:
+                                              type: string
+                                          required:
+                                          - registry
+                                          - volume
+                                          type: object
+                                        rbd:
+                                          properties:
+                                            fsType:
+                                              type: string
+                                            image:
+                                              type: string
+                                            keyring:
+                                              type: string
+                                            monitors:
+                                              items:
+                                                type: string
+                                              type: array
+                                            pool:
+                                              type: string
+                                            readOnly:
+                                              type: boolean
+                                            secretRef:
+                                              properties:
+                                                name:
+                                                  type: string
+                                              type: object
+                                            user:
+                                              type: string
+                                          required:
+                                          - image
+                                          - monitors
+                                          type: object
+                                        scaleIO:
+                                          properties:
+                                            fsType:
+                                              type: string
+                                            gateway:
+                                              type: string
+                                            protectionDomain:
+                                              type: string
+                                            readOnly:
+                                              type: boolean
+                                            secretRef:
+                                              properties:
+                                                name:
+                                                  type: string
+                                              type: object
+                                            sslEnabled:
+                                              type: boolean
+                                            storageMode:
+                                              type: string
+                                            storagePool:
+                                              type: string
+                                            system:
+                                              type: string
+                                            volumeName:
+                                              type: string
+                                          required:
+                                          - gateway
+                                          - secretRef
+                                          - system
+                                          type: object
+                                        secret:
+                                          properties:
+                                            defaultMode:
+                                              format: int32
+                                              type: integer
+                                            items:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  mode:
+                                                    format: int32
+                                                    type: integer
+                                                  path:
+                                                    type: string
+                                                required:
+                                                - key
+                                                - path
+                                                type: object
+                                              type: array
+                                            optional:
+                                              type: boolean
+                                            secretName:
+                                              type: string
+                                          type: object
+                                        storageos:
+                                          properties:
+                                            fsType:
+                                              type: string
+                                            readOnly:
+                                              type: boolean
+                                            secretRef:
+                                              properties:
+                                                name:
+                                                  type: string
+                                              type: object
+                                            volumeName:
+                                              type: string
+                                            volumeNamespace:
+                                              type: string
+                                          type: object
+                                        vsphereVolume:
+                                          properties:
+                                            fsType:
+                                              type: string
+                                            storagePolicyID:
+                                              type: string
+                                            storagePolicyName:
+                                              type: string
+                                            volumePath:
+                                              type: string
+                                          required:
+                                          - volumePath
+                                          type: object
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                type: object
+                            type: object
+                          updateStrategy:
+                            properties:
+                              rollingUpdate:
+                                properties:
+                                  maxSurge:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    x-kubernetes-int-or-string: true
+                                  maxUnavailable:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    x-kubernetes-int-or-string: true
+                                type: object
+                              type:
+                                type: string
+                            type: object
+                        type: object
+                    type: object
+                  disableKubernetesFilter:
+                    type: boolean
+                  enableUpstream:
+                    type: boolean
+                  enabled:
+                    type: boolean
+                  extraVolumeMounts:
+                    items:
+                      properties:
+                        destination:
+                          pattern: ^/.+$
+                          type: string
+                        readOnly:
+                          type: boolean
+                        source:
+                          pattern: ^/.+$
+                          type: string
+                      required:
+                      - destination
+                      - source
+                      type: object
+                    type: array
+                  filterAws:
+                    properties:
+                      Match:
+                        type: string
+                      account_id:
+                        type: boolean
+                      ami_id:
+                        type: boolean
+                      az:
+                        type: boolean
+                      ec2_instance_id:
+                        type: boolean
+                      ec2_instance_type:
+                        type: boolean
+                      hostname:
+                        type: boolean
+                      imds_version:
+                        type: string
+                      private_ip:
+                        type: boolean
+                      vpc_id:
+                        type: boolean
+                    type: object
+                  filterKubernetes:
+                    properties:
+                      Annotations:
+                        type: string
+                      Buffer_Size:
+                        type: string
+                      Cache_Use_Docker_Id:
+                        type: string
+                      DNS_Retries:
+                        type: string
+                      DNS_Wait_Time:
+                        type: string
+                      Dummy_Meta:
+                        type: string
+                      K8S-Logging.Exclude:
+                        type: string
+                      K8S-Logging.Parser:
+                        type: string
+                      Keep_Log:
+                        type: string
+                      Kube_CA_File:
+                        type: string
+                      Kube_CA_Path:
+                        type: string
+                      Kube_Meta_Cache_TTL:
+                        type: string
+                      Kube_Tag_Prefix:
+                        type: string
+                      Kube_Token_File:
+                        type: string
+                      Kube_Token_TTL:
+                        type: string
+                      Kube_URL:
+                        type: string
+                      Kube_meta_preload_cache_dir:
+                        type: string
+                      Kubelet_Port:
+                        type: string
+                      Labels:
+                        type: string
+                      Match:
+                        type: string
+                      Merge_Log:
+                        type: string
+                      Merge_Log_Key:
+                        type: string
+                      Merge_Log_Trim:
+                        type: string
+                      Merge_Parser:
+                        type: string
+                      Regex_Parser:
+                        type: string
+                      Use_Journal:
+                        type: string
+                      Use_Kubelet:
+                        type: string
+                      tls.debug:
+                        type: string
+                      tls.verify:
+                        type: string
+                    type: object
+                  flush:
+                    format: int32
+                    type: integer
+                  forwardOptions:
+                    properties:
+                      Require_ack_response:
+                        type: boolean
+                      Retry_Limit:
+                        type: string
+                      Send_options:
+                        type: boolean
+                      Tag:
+                        type: string
+                      Time_as_Integer:
+                        type: boolean
+                      storage.total_limit_size:
+                        type: string
+                    type: object
+                  grace:
+                    format: int32
+                    type: integer
+                  inputTail:
+                    properties:
+                      Buffer_Chunk_Size:
+                        type: string
+                      Buffer_Max_Size:
+                        type: string
+                      DB:
+                        type: string
+                      DB.journal_mode:
+                        type: string
+                      DB.locking:
+                        type: boolean
+                      DB_Sync:
+                        type: string
+                      Docker_Mode:
+                        type: string
+                      Docker_Mode_Flush:
+                        type: string
+                      Docker_Mode_Parser:
+                        type: string
+                      Exclude_Path:
+                        type: string
+                      Ignore_Older:
+                        type: string
+                      Key:
+                        type: string
+                      Mem_Buf_Limit:
+                        type: string
+                      Multiline:
+                        type: string
+                      Multiline_Flush:
+                        type: string
+                      Parser:
+                        type: string
+                      Parser_Firstline:
+                        type: string
+                      Parser_N:
+                        items:
+                          type: string
+                        type: array
+                      Path:
+                        type: string
+                      Path_Key:
+                        type: string
+                      Read_From_Head:
+                        type: boolean
+                      Refresh_Interval:
+                        type: string
+                      Rotate_Wait:
+                        type: string
+                      Skip_Long_Lines:
+                        type: string
+                      Tag:
+                        type: string
+                      Tag_Regex:
+                        type: string
+                      multiline.parser:
+                        items:
+                          type: string
+                        type: array
+                      storage.type:
+                        type: string
+                    type: object
+                  livenessDefaultCheck:
+                    type: boolean
+                  logLevel:
+                    type: string
+                  metrics:
+                    properties:
+                      interval:
+                        type: string
+                      path:
+                        type: string
+                      port:
+                        format: int32
+                        type: integer
+                      prometheusAnnotations:
+                        type: boolean
+                      prometheusRules:
+                        type: boolean
+                      serviceMonitor:
+                        type: boolean
+                      serviceMonitorConfig:
+                        properties:
+                          additionalLabels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          honorLabels:
+                            type: boolean
+                          metricRelabelings:
+                            items:
+                              properties:
+                                action:
+                                  default: replace
+                                  enum:
+                                  - replace
+                                  - Replace
+                                  - keep
+                                  - Keep
+                                  - drop
+                                  - Drop
+                                  - hashmod
+                                  - HashMod
+                                  - labelmap
+                                  - LabelMap
+                                  - labeldrop
+                                  - LabelDrop
+                                  - labelkeep
+                                  - LabelKeep
+                                  - lowercase
+                                  - Lowercase
+                                  - uppercase
+                                  - Uppercase
+                                  type: string
+                                modulus:
+                                  format: int64
+                                  type: integer
+                                regex:
+                                  type: string
+                                replacement:
+                                  type: string
+                                separator:
+                                  type: string
+                                sourceLabels:
+                                  items:
+                                    pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                                    type: string
+                                  type: array
+                                targetLabel:
+                                  type: string
+                              type: object
+                            type: array
+                          relabelings:
+                            items:
+                              properties:
+                                action:
+                                  default: replace
+                                  enum:
+                                  - replace
+                                  - Replace
+                                  - keep
+                                  - Keep
+                                  - drop
+                                  - Drop
+                                  - hashmod
+                                  - HashMod
+                                  - labelmap
+                                  - LabelMap
+                                  - labeldrop
+                                  - LabelDrop
+                                  - labelkeep
+                                  - LabelKeep
+                                  - lowercase
+                                  - Lowercase
+                                  - uppercase
+                                  - Uppercase
+                                  type: string
+                                modulus:
+                                  format: int64
+                                  type: integer
+                                regex:
+                                  type: string
+                                replacement:
+                                  type: string
+                                separator:
+                                  type: string
+                                sourceLabels:
+                                  items:
+                                    pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                                    type: string
+                                  type: array
+                                targetLabel:
+                                  type: string
+                              type: object
+                            type: array
+                          scheme:
+                            type: string
+                          tlsConfig:
+                            properties:
+                              ca:
+                                properties:
+                                  configMap:
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  secret:
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                type: object
+                              caFile:
+                                type: string
+                              cert:
+                                properties:
+                                  configMap:
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  secret:
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                type: object
+                              certFile:
+                                type: string
+                              insecureSkipVerify:
+                                type: boolean
+                              keyFile:
+                                type: string
+                              keySecret:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                              serverName:
+                                type: string
+                            type: object
+                        type: object
+                      timeout:
+                        type: string
+                    type: object
+                  metricsService:
+                    properties:
+                      metadata:
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          labels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        type: object
+                      spec:
+                        properties:
+                          allocateLoadBalancerNodePorts:
+                            type: boolean
+                          clusterIP:
+                            type: string
+                          clusterIPs:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          externalIPs:
+                            items:
+                              type: string
+                            type: array
+                          externalName:
+                            type: string
+                          externalTrafficPolicy:
+                            type: string
+                          healthCheckNodePort:
+                            format: int32
+                            type: integer
+                          internalTrafficPolicy:
+                            type: string
+                          ipFamilies:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          ipFamilyPolicy:
+                            type: string
+                          loadBalancerClass:
+                            type: string
+                          loadBalancerIP:
+                            type: string
+                          loadBalancerSourceRanges:
+                            items:
+                              type: string
+                            type: array
+                          ports:
+                            items:
+                              properties:
+                                appProtocol:
+                                  type: string
+                                name:
+                                  type: string
+                                nodePort:
+                                  format: int32
+                                  type: integer
+                                port:
+                                  format: int32
+                                  type: integer
+                                protocol:
+                                  default: TCP
+                                  type: string
+                                targetPort:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - port
+                            - protocol
+                            x-kubernetes-list-type: map
+                          publishNotReadyAddresses:
+                            type: boolean
+                          selector:
+                            additionalProperties:
+                              type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          sessionAffinity:
+                            type: string
+                          sessionAffinityConfig:
+                            properties:
+                              clientIP:
+                                properties:
+                                  timeoutSeconds:
+                                    format: int32
+                                    type: integer
+                                type: object
+                            type: object
+                          type:
+                            type: string
+                        type: object
+                    type: object
+                  network:
+                    properties:
+                      connectTimeout:
+                        format: int32
+                        type: integer
+                      connectTimeoutLogError:
+                        type: boolean
+                      dnsMode:
+                        type: string
+                      dnsPreferIpv4:
+                        type: boolean
+                      dnsResolver:
+                        type: string
+                      keepalive:
+                        type: boolean
+                      keepaliveIdleTimeout:
+                        format: int32
+                        type: integer
+                      keepaliveMaxRecycle:
+                        format: int32
+                        type: integer
+                      sourceAddress:
+                        type: string
+                    type: object
+                  podPriorityClassName:
+                    type: string
+                  positiondb:
+                    properties:
+                      emptyDir:
+                        properties:
+                          medium:
+                            type: string
+                          sizeLimit:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      host_path:
+                        properties:
+                          path:
+                            type: string
+                          type:
+                            type: string
+                        required:
+                        - path
+                        type: object
+                      hostPath:
+                        properties:
+                          path:
+                            type: string
+                          type:
+                            type: string
+                        required:
+                        - path
+                        type: object
+                      pvc:
+                        properties:
+                          source:
+                            properties:
+                              claimName:
+                                type: string
+                              readOnly:
+                                type: boolean
+                            required:
+                            - claimName
+                            type: object
+                          spec:
+                            properties:
+                              accessModes:
+                                items:
+                                  type: string
+                                type: array
+                              dataSource:
+                                properties:
+                                  apiGroup:
+                                    type: string
+                                  kind:
+                                    type: string
+                                  name:
+                                    type: string
+                                required:
+                                - kind
+                                - name
+                                type: object
+                              dataSourceRef:
+                                properties:
+                                  apiGroup:
+                                    type: string
+                                  kind:
+                                    type: string
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
+                                required:
+                                - kind
+                                - name
+                                type: object
+                              resources:
+                                properties:
+                                  claims:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - name
+                                    x-kubernetes-list-type: map
+                                  limits:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    type: object
+                                  requests:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    type: object
+                                type: object
+                              selector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                              storageClassName:
+                                type: string
+                              volumeMode:
+                                type: string
+                              volumeName:
+                                type: string
+                            type: object
+                        type: object
+                    type: object
+                  security:
+                    properties:
+                      podSecurityContext:
+                        properties:
+                          fsGroup:
+                            format: int64
+                            type: integer
+                          fsGroupChangePolicy:
+                            type: string
+                          runAsGroup:
+                            format: int64
+                            type: integer
+                          runAsNonRoot:
+                            type: boolean
+                          runAsUser:
+                            format: int64
+                            type: integer
+                          seLinuxOptions:
+                            properties:
+                              level:
+                                type: string
+                              role:
+                                type: string
+                              type:
+                                type: string
+                              user:
+                                type: string
+                            type: object
+                          seccompProfile:
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
+                            required:
+                            - type
+                            type: object
+                          supplementalGroups:
+                            items:
+                              format: int64
+                              type: integer
+                            type: array
+                          sysctls:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                          windowsOptions:
+                            properties:
+                              gmsaCredentialSpec:
+                                type: string
+                              gmsaCredentialSpecName:
+                                type: string
+                              hostProcess:
+                                type: boolean
+                              runAsUserName:
+                                type: string
+                            type: object
+                        type: object
+                      podSecurityPolicyCreate:
+                        type: boolean
+                      roleBasedAccessControlCreate:
+                        type: boolean
+                      securityContext:
+                        properties:
+                          allowPrivilegeEscalation:
+                            type: boolean
+                          capabilities:
+                            properties:
+                              add:
+                                items:
+                                  type: string
+                                type: array
+                              drop:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          privileged:
+                            type: boolean
+                          procMount:
+                            type: string
+                          readOnlyRootFilesystem:
+                            type: boolean
+                          runAsGroup:
+                            format: int64
+                            type: integer
+                          runAsNonRoot:
+                            type: boolean
+                          runAsUser:
+                            format: int64
+                            type: integer
+                          seLinuxOptions:
+                            properties:
+                              level:
+                                type: string
+                              role:
+                                type: string
+                              type:
+                                type: string
+                              user:
+                                type: string
+                            type: object
+                          seccompProfile:
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
+                            required:
+                            - type
+                            type: object
+                          windowsOptions:
+                            properties:
+                              gmsaCredentialSpec:
+                                type: string
+                              gmsaCredentialSpecName:
+                                type: string
+                              hostProcess:
+                                type: boolean
+                              runAsUserName:
+                                type: string
+                            type: object
+                        type: object
+                      serviceAccount:
+                        type: string
+                    type: object
+                  serviceAccount:
+                    properties:
+                      automountServiceAccountToken:
+                        type: boolean
+                      imagePullSecrets:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                          type: object
+                        type: array
+                      metadata:
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          labels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        type: object
+                      secrets:
+                        items:
+                          properties:
+                            apiVersion:
+                              type: string
+                            fieldPath:
+                              type: string
+                            kind:
+                              type: string
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                            resourceVersion:
+                              type: string
+                            uid:
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  targetHost:
+                    type: string
+                  targetPort:
+                    format: int32
+                    type: integer
+                  tls:
+                    properties:
+                      enabled:
+                        type: boolean
+                      secretName:
+                        type: string
+                      sharedKey:
+                        type: string
+                    required:
+                    - enabled
+                    type: object
+                  varLogsPath:
+                    type: string
+                type: object
+              profile:
+                type: string
+            type: object
+          status:
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/charts/logging-operator/crds/logging.banzaicloud.io_syslogngclusteroutputs.yaml
+++ b/charts/logging-operator/crds/logging.banzaicloud.io_syslogngclusteroutputs.yaml
@@ -554,6 +554,19 @@ spec:
                 required:
                 - token
                 type: object
+              mqtt:
+                properties:
+                  address:
+                    type: string
+                  fallback-topic:
+                    type: string
+                  qos:
+                    type: integer
+                  template:
+                    type: string
+                  topic:
+                    type: string
+                type: object
               sumologic-http:
                 properties:
                   batch-bytes:

--- a/charts/logging-operator/crds/logging.banzaicloud.io_syslogngoutputs.yaml
+++ b/charts/logging-operator/crds/logging.banzaicloud.io_syslogngoutputs.yaml
@@ -550,6 +550,19 @@ spec:
                 required:
                 - token
                 type: object
+              mqtt:
+                properties:
+                  address:
+                    type: string
+                  fallback-topic:
+                    type: string
+                  qos:
+                    type: integer
+                  template:
+                    type: string
+                  topic:
+                    type: string
+                type: object
               sumologic-http:
                 properties:
                   batch-bytes:

--- a/charts/logging-operator/templates/clusterrole.yaml
+++ b/charts/logging-operator/templates/clusterrole.yaml
@@ -242,6 +242,7 @@ rules:
   - clusteroutputs
   - flows
   - loggings
+  - nodeagents
   - outputs
   verbs:
   - create
@@ -258,6 +259,7 @@ rules:
   - clusteroutputs/status
   - flows/status
   - loggings/status
+  - nodeagents/status
   - outputs/status
   verbs:
   - get

--- a/charts/logging-operator/templates/deployment.yaml
+++ b/charts/logging-operator/templates/deployment.yaml
@@ -33,7 +33,7 @@ spec:
     {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           args:
           {{- range .Values.extraArgs }}
             - {{ . }}

--- a/charts/logging-operator/values.yaml
+++ b/charts/logging-operator/values.yaml
@@ -9,7 +9,7 @@ image:
   repository: ghcr.io/kube-logging/logging-operator
 
   # -- Image tag override for the default value (chart appVersion).
-  tag: 4.0.0
+  tag: ""
 
   # -- [Image pull policy](https://kubernetes.io/docs/concepts/containers/images/#updating-images) for updating already existing images on a node.
   pullPolicy: IfNotPresent


### PR DESCRIPTION
Charts should be updated based on the charts in the logging-operator repo under e2e/charts
