### PR TITLE
chore: bump image and chart versions

### DIFF
--- a/charts/logging-operator-logging/Chart.yaml
+++ b/charts/logging-operator-logging/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: logging-operator-logging
-version: 4.2.0
+version: 4.2.1
 kubeVersion: ">=1.22"
 description: A Helm chart to configure logging resource for the Logging operator.
 keywords:
@@ -24,7 +24,7 @@ annotations:
     - name: syslog-ng
       image: ghcr.io/axoflow/axosyslog:4.2.0
     - name: logging-operator
-      image: ghcr.io/kube-logging/logging-operator:4.2.0
+      image: ghcr.io/kube-logging/logging-operator:4.2.1
     - name: config-reloader
       image: ghcr.io/kube-logging/config-reloader:v0.0.5
     - name: node-exporter

--- a/charts/logging-operator-logging/README.md
+++ b/charts/logging-operator-logging/README.md
@@ -1,6 +1,6 @@
 # logging-operator-logging
 
-![version: 4.2.0](https://img.shields.io/badge/version-4.2.0-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square)  ![kube version: >=1.22](https://img.shields.io/badge/kube%20version->=1.22-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-logging--operator--logging-informational?style=flat-square)](https://artifacthub.io/packages/helm/kube-logging/logging-operator-logging)
+![version: 4.2.1](https://img.shields.io/badge/version-4.2.1-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square)  ![kube version: >=1.22](https://img.shields.io/badge/kube%20version->=1.22-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-logging--operator--logging-informational?style=flat-square)](https://artifacthub.io/packages/helm/kube-logging/logging-operator-logging)
 
 A Helm chart to configure logging resource for the Logging operator.
 

--- a/charts/logging-operator/Chart.yaml
+++ b/charts/logging-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 type: application
 name: logging-operator
-version: 4.2.0
-appVersion: 4.2.0
+version: 4.2.1
+appVersion: 4.2.1
 kubeVersion: ">=1.22"
 description: Logging operator for Kubernetes based on Fluentd and Fluentbit.
 keywords:
@@ -19,4 +19,4 @@ annotations:
       description: Moved to to location
   artifacthub.io/images: |
     - name: logging-operator
-      image: ghcr.io/kube-logging/logging-operator:4.2.0
+      image: ghcr.io/kube-logging/logging-operator:4.2.1

--- a/charts/logging-operator/README.md
+++ b/charts/logging-operator/README.md
@@ -1,6 +1,6 @@
 # logging-operator
 
-![version: 4.2.0](https://img.shields.io/badge/version-4.2.0-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 4.2.0](https://img.shields.io/badge/app%20version-4.2.0-informational?style=flat-square) ![kube version: >=1.22](https://img.shields.io/badge/kube%20version->=1.22-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-logging--operator-informational?style=flat-square)](https://artifacthub.io/packages/helm/kube-logging/logging-operator)
+![version: 4.2.1](https://img.shields.io/badge/version-4.2.1-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 4.2.1](https://img.shields.io/badge/app%20version-4.2.1-informational?style=flat-square) ![kube version: >=1.22](https://img.shields.io/badge/kube%20version->=1.22-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-logging--operator-informational?style=flat-square)](https://artifacthub.io/packages/helm/kube-logging/logging-operator)
 
 Logging operator for Kubernetes based on Fluentd and Fluentbit.
 


### PR DESCRIPTION
Bump image version to use logging operator 4.2.1 by default, which contains and important fix for fluentbit: https://github.com/kube-logging/logging-operator/releases/tag/4.2.1